### PR TITLE
Add env var to ignore sklearn package name issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
 
         NEAT_DIR = '~jenkinsuser/NEAT'
         NEAT_SCHEDULER_DIR = '~jenkinsuser/NEAT-kghub-scheduler'
+        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
     }
 
     options {


### PR DESCRIPTION
This will be solved if NEAT no longer uses scikit-learn, but for now it's a workaround.